### PR TITLE
修复书架中包含样章时无法正常下载的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 3. 复制js代码
 
 ```jsx
-//最终版本 v5.1
+//最终版本 v5.2
 
 // 主程序
 function repeatProcess() {
@@ -42,6 +42,9 @@ function repeatProcess() {
     let elements = document.querySelectorAll('[id^="content-title-"]');
     let ids = [];
     for (let i = 0; i < elements.length; i++) {
+        if (elements[i].parentElement.textContent.includes("样章")) {
+            continue
+        }
         let id = elements[i].id;
         let uniquePart = id.replace("content-title-", ""); // 这将从ID中删除 "content-title-"。
         ids.push(uniquePart);
@@ -68,18 +71,26 @@ function downloadItems(ids, i = 0) {
         let DOWNLOAD_AND_TRANSFER_ACTION = "DOWNLOAD_AND_TRANSFER_ACTION_" + ids[i];
         let download_and_transfer_list = "download_and_transfer_list_" + ids[i] + "_0";
         let DOWNLOAD_AND_TRANSFER_ACTION_CONFIRM = "DOWNLOAD_AND_TRANSFER_ACTION_" + ids[i] + "_CONFIRM";
-        
-        // 点击元素
-        document.getElementById(DOWNLOAD_AND_TRANSFER_ACTION).click();
-        document.getElementById(download_and_transfer_list).click();
-        document.getElementById(DOWNLOAD_AND_TRANSFER_ACTION_CONFIRM).click();
+
+        // 获取元素
+        let actionElement = document.getElementById(DOWNLOAD_AND_TRANSFER_ACTION);
+        let listElement = document.getElementById(download_and_transfer_list);
+        let confirmElement = document.getElementById(DOWNLOAD_AND_TRANSFER_ACTION_CONFIRM);
+
+        // 检查元素存在并点击
+        if(actionElement) actionElement.click();
+        if(listElement) listElement.click();
+        if(confirmElement) confirmElement.click();
 
         // 在关闭通知前增加一个延迟
         setTimeout(function() {
-          document.getElementById("notification-close").click();
-          setTimeout(function() {
-            downloadItems(ids, i + 1);  // 继续下一步下载
-          }, 2000);  // 在下次下载前增加一个延迟
+          let notificationClose = document.getElementById("notification-close");
+          if(notificationClose) {
+            notificationClose.click();
+            setTimeout(function() {
+              downloadItems(ids, i + 1);  // 继续下一步下载
+            }, 2000);  // 在下次下载前增加一个延迟
+          }
         }, 1000);
     }
 }


### PR DESCRIPTION
##### 修复方式: 下载时跳过样章

##### 原因:
样章是无法下载的, 在 html 中不会包含下载按钮, 当书架中包含样章时, 现有的 5.1 版代码会报错并停止执行, 错误信息:
```
Uncaught TypeError: Cannot read properties of null (reading 'click')
    at downloadItems (<anonymous>:37:62)
    at <anonymous>:45:13
```

例如下图这种情况, 执行时, 只会下载第一本书, 而不是下载全部书籍.
<img width="641" alt="image" src="https://github.com/yaleax/kindleAutoDownload/assets/4291901/7c28f662-c33a-4132-a80a-37cac61c94e2">
